### PR TITLE
Release: DataGate Monitor stack (Pi-hole, cert expiry, OpenVPN SignalR, GDPR)

### DIFF
--- a/.cursor/rules/git-commit-messages.mdc
+++ b/.cursor/rules/git-commit-messages.mdc
@@ -7,5 +7,7 @@ alwaysApply: true
 
 - Write commit messages in English unless the user explicitly asks for another language.
 - Do **not** add attribution lines such as `Made-with: Cursor`, `Co-authored-by: Cursor`, or similar tool/agent footers.
+- After clone, run `./scripts/setup-git-hooks.sh` to strip any Cursor trailers before commits land locally.
+- In Cursor: **Settings → Agents → Attribution** — disable Commit Attribution and PR Attribution; set `"attributeCommitsToAgent": false` in `~/.cursor/cli-config.json`.
 - Keep messages focused on **why** the change was made; one or two sentences is enough for simple fixes.
 - When bumping a service version, update `Version`, `AssemblyVersion`, and `FileVersion` together in the same commit.

--- a/.cursor/rules/nuget-org-and-orval-only.mdc
+++ b/.cursor/rules/nuget-org-and-orval-only.mdc
@@ -1,0 +1,25 @@
+---
+description: Restore SharedModels only from nuget.org; frontend API types only via Orval from OpenAPI.
+alwaysApply: true
+---
+
+# NuGet.org only + Orval for frontend API
+
+## SharedModels / backend restore
+
+- Restore and build **only** from **nuget.org** (`nuget.config` has `<clear />` + nuget.org — keep it that way).
+- **Forbidden** to unblock builds:
+  - `dotnet pack` into `/tmp/nuget-local` (or any local folder) and restore with `--source` that folder
+  - `dotnet nuget add source` for ad-hoc local feeds
+  - `<ProjectReference>` to `DataGateMonitor.SharedModels`
+- If `PackageReference` version is **not on nuget.org**: publish via `nuget/release/v*`, wait for indexing, then bump consumers — **do not** substitute local packages.
+
+## Frontend API client
+
+- **All** backend HTTP contracts (types + hooks) come from **Orval** (`npm run gen:api`) against `frontend/openapi/swagger.json` or live `/swagger/v1/swagger.json`.
+- **Do not** add hand-written `src/api/*Api.ts` files that duplicate DTOs (exception: tiny pure helpers like label formatters in `src/utils/`, with types imported from `src/api/orval/`).
+- After new/changed controllers or SharedModels DTOs:
+  1. Publish SharedModels if needed
+  2. Export/update `frontend/openapi/swagger.json` from running API
+  3. Run `npm run gen:api`
+  4. Wire UI to generated hooks under `src/api/orval/`

--- a/.cursor/rules/sharedmodels-nuget-only.mdc
+++ b/.cursor/rules/sharedmodels-nuget-only.mdc
@@ -9,3 +9,4 @@ alwaysApply: true
 - **Always** use `<PackageReference Include="DataGateMonitor.SharedModels" Version="…" />` and restore from NuGet (or your CI’s configured feeds).
 - If the code needs new types or enum members in SharedModels: bump the **package version** in `DataGateMonitor.SharedModels.csproj`, publish the package, then bump `Version="…"` in all consuming `.csproj` files. Do **not** substitute a project reference to “unblock” the build.
 - Docker/backend restore must **not** copy `DataGateMonitor.SharedModels.csproj` for restore unless the image is explicitly building that package—default layout assumes SharedModels comes from NuGet.
+- **Never** use local NuGet feeds (`dotnet pack -o /tmp/...`, `--source /tmp/...`, extra `packageSources`) to bypass a missing version — publish to nuget.org first. See also `nuget-org-and-orval-only.mdc`.

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Strip Cursor agent attribution injected by IDE/CLI.
+MSG_FILE="$1"
+[ -n "$MSG_FILE" ] && [ -f "$MSG_FILE" ] || exit 0
+
+sed -i \
+  -e '/^Co-authored-by: Cursor <cursoragent@cursor\.com>$/d' \
+  -e '/^Made-with: Cursor$/d' \
+  "$MSG_FILE"
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ openvpn-data-tcp
 *.key
 .idea/
 .vs/
+backups/
+*.dump

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "backend"]
 	path = backend
-	url = https://github.com/IMKolganov/OpenVPNGateMonitorBackend
+	url = https://github.com/IMKolganov/DataGateMonitorBackend.git
 [submodule "frontend"]
 	path = frontend
-	url = https://github.com/IMKolganov/OpenVpnGateMonitorFrontend
+	url = https://github.com/IMKolganov/DataGateMonitorFrontend.git
 [submodule "telegrambot"]
 	path = telegrambot
 	url = https://github.com/IMKolganov/DataGateVPNBot

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="local-packages" value="backend/local-packages" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local-packages" value="backend/local-packages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/scripts/fix-monorepo-submodule-gitlinks.sh
+++ b/scripts/fix-monorepo-submodule-gitlinks.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="/home/imkolganov/Projects/DataGateMonitor"
+MAP_DIR=$(mktemp -d)
+trap 'rm -rf "$MAP_DIR"' EXIT
+
+build_tree_map() {
+  local repo="$1"
+  local out="$2"
+  : > "$out"
+  git -C "$repo" rev-list --all | while read -r sha; do
+    tree=$(git -C "$repo" rev-parse "$sha^{tree}")
+    if ! awk -v t="$tree" '$1==t {found=1; exit} END{exit !found}' "$out"; then
+      echo "$tree $sha" >> "$out"
+    fi
+  done
+  echo "    $1 tree map: $(wc -l < "$out") entries"
+}
+
+build_tree_map "$ROOT/backend" "$MAP_DIR/backend-trees.txt"
+build_tree_map "$ROOT/frontend" "$MAP_DIR/frontend-trees.txt"
+
+lookup_new_sha() {
+  local repo="$1"
+  local old_sha="$2"
+  local map_file="$3"
+  local tree
+  tree=$(git -C "$repo" rev-parse "$old_sha^{tree}" 2>/dev/null) || return 0
+  awk -v t="$tree" '$1==t {print $2; exit}' "$map_file"
+}
+
+export ROOT MAP_DIR
+export -f lookup_new_sha
+
+tree_filter='
+  for path in backend frontend; do
+    sha=$(git ls-tree HEAD "$path" 2>/dev/null | awk "{print \$3}")
+    [ -n "$sha" ] || continue
+    repo="$ROOT/$path"
+    map="$MAP_DIR/${path}-trees.txt"
+    newsha=$(lookup_new_sha "$repo" "$sha" "$map")
+    if [ -n "$newsha" ] && [ "$newsha" != "$sha" ]; then
+      git update-index --cacheinfo 160000,"$newsha","$path"
+    fi
+  done
+'
+
+export FILTER_BRANCH_SQUELCH_WARNING=1
+git -C "$ROOT" filter-branch -f --tree-filter "$tree_filter" -- --all
+git -C "$ROOT" for-each-ref --format='%(refname)' refs/original/ \
+  | xargs -r -n1 git -C "$ROOT" update-ref -d
+
+echo ">>> monorepo gitlinks after fix"
+git -C "$ROOT" ls-tree main backend frontend
+git -C "$ROOT" ls-tree develop backend frontend

--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK_SRC="$ROOT/.githooks/prepare-commit-msg"
+
+resolve_git_dir() {
+  local repo_path="$1"
+  local git_entry="$repo_path/.git"
+
+  if [ -d "$git_entry" ]; then
+    echo "$git_entry"
+    return
+  fi
+
+  if [ -f "$git_entry" ]; then
+    local gitdir
+    gitdir="$(sed -n 's/^gitdir: //p' "$git_entry")"
+    if [[ "$gitdir" != /* ]]; then
+      gitdir="$repo_path/$gitdir"
+    fi
+    echo "$(cd "$(dirname "$gitdir")" && pwd)/$(basename "$gitdir")"
+  fi
+}
+
+install_hook() {
+  local repo_path="$1"
+  local git_dir
+  git_dir="$(resolve_git_dir "$repo_path")"
+
+  [ -n "$git_dir" ] && [ -d "$git_dir" ] || return 0
+
+  local hook_dir="$git_dir/hooks"
+  local hook_dst="$hook_dir/prepare-commit-msg"
+
+  mkdir -p "$hook_dir"
+  cp "$HOOK_SRC" "$hook_dst"
+  chmod +x "$hook_dst"
+}
+
+install_hook "$ROOT"
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  install_hook "$ROOT/$path"
+done < <(git -C "$ROOT" config --file .gitmodules --get-regexp path 2>/dev/null | awk '{print $2}')
+
+echo "Installed prepare-commit-msg hook in monorepo and submodules."

--- a/scripts/strip-cursor-attribution-history.sh
+++ b/scripts/strip-cursor-attribution-history.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MSG_FILTER='sed -e "/^Co-authored-by: Cursor <cursoragent@cursor.com>$/d" -e "/^Made-with: Cursor$/d"'
+
+strip_cursor_trailers() {
+  local repo="$1"
+  echo ">>> Rewriting commit messages in $repo"
+  git -C "$repo" filter-branch -f \
+    --msg-filter "$MSG_FILTER" \
+    --tag-name-filter cat \
+    -- --all
+  git -C "$repo" for-each-ref --format='%(refname)' refs/original/ \
+    | xargs -r -n1 git -C "$repo" update-ref -d
+}
+
+build_sha_map() {
+  local repo="$1"
+  local out="$2"
+  : > "$out"
+  git -C "$repo" for-each-ref --format='%(refname)' refs/original/ | while read -r origref; do
+    newref="${origref#refs/original/}"
+    paste \
+      <(git -C "$repo" rev-list --reverse "$origref") \
+      <(git -C "$repo" rev-list --reverse "$newref")
+  done | awk '!seen[$1]++' >> "$out"
+  echo "    map entries: $(wc -l < "$out")"
+}
+
+update_submodule_gitlinks() {
+  local repo="$1"
+  local map_dir="$2"
+  echo ">>> Updating submodule gitlinks in $repo"
+
+  local tree_filter=''
+  tree_filter='
+    for path in backend frontend openvpn xray telegrambot; do
+      sha=$(git ls-tree HEAD "$path" 2>/dev/null | awk "{print \$3}")
+      [ -n "$sha" ] || continue
+      mapfile="'"$map_dir"'/${path}-map.txt"
+      if [ -f "$mapfile" ]; then
+        newsha=$(awk -v old="$sha" "$1==old {print $2; exit}" "$mapfile")
+        if [ -n "$newsha" ] && [ "$newsha" != "$sha" ]; then
+          git update-index --cacheinfo 160000,"$newsha","$path"
+        fi
+      fi
+    done
+  '
+
+  git -C "$repo" filter-branch -f \
+    --msg-filter "$MSG_FILTER" \
+    --tree-filter "$tree_filter" \
+    --tag-name-filter cat \
+    -- --all
+
+  git -C "$repo" for-each-ref --format='%(refname)' refs/original/ \
+    | xargs -r -n1 git -C "$repo" update-ref -d
+}
+
+ROOT="/home/imkolganov/Projects/DataGateMonitor"
+MAP_DIR=$(mktemp -d)
+export FILTER_BRANCH_SQUELCH_WARNING=1
+
+strip_cursor_trailers "$ROOT/backend"
+build_sha_map "$ROOT/backend" "$MAP_DIR/backend-map.txt"
+
+strip_cursor_trailers "$ROOT/frontend"
+build_sha_map "$ROOT/frontend" "$MAP_DIR/frontend-map.txt"
+
+update_submodule_gitlinks "$ROOT" "$MAP_DIR"
+
+rm -rf "$MAP_DIR"
+
+echo ">>> Verify no cursoragent left"
+for repo in "$ROOT" "$ROOT/backend" "$ROOT/frontend"; do
+  name=$(basename "$repo")
+  [ "$repo" = "$ROOT" ] && name="monorepo"
+  if git -C "$repo" log --all --format=%B | grep -qi cursoragent; then
+    echo "FAIL: still found in $name"
+    exit 1
+  fi
+  echo "OK: $name clean"
+done
+
+echo "Done. Force-push develop/main in each repo when ready."


### PR DESCRIPTION
## Summary

Release `develop` → `main` for the **DataGate Monitor** monorepo. All submodules are pinned to their **`main`** release commits.

| Submodule | SHA | Release |
|-----------|-----|---------|
| **backend** | `382e7fa3` | [PR #168](https://github.com/IMKolganov/DataGateMonitorBackend/pull/168) — v1.0.3.57 |
| **frontend** | `df63c6b` | [PR #111](https://github.com/IMKolganov/DataGateMonitorFrontend/pull/111) — v1.4.6 |
| **openvpn** | `02988c7` | [PR #29](https://github.com/IMKolganov/DataGateOpenVpnManager/pull/29) — v1.2.5.78 |
| **telegrambot** | `a1b7523` | [PR #107](https://github.com/IMKolganov/OpenVPNGateBot/pull/107) |
| **xray** | `a78e423` | [PR #11](https://github.com/IMKolganov/DataGateXRayManager/pull/11) |

---

### Backend (`DataGateMonitorBackend`)

- **OpenVPN & SignalR** — user events filter API, client app version summary; fix `HubConnection` startup race; factory URL invalidation; shared reconnect policy (0/2/5/15/30/60s).
- **OpenVPN 2.7** — parse new management `Real Address` format; normalize remote IP for session IDs.
- **Pi-hole DNS** — per-server config API, DNS query logging, top domains, search by user VPN profiles; health checks with admin alerts on failure/recovery.
- **Certificate expiry** — hourly monitoring + manual runs with history and admin notifications.
- **SharedModels** — 1.0.26–1.0.34 (Pi-hole, cert expiry, OpenVPN events, app versions).
- **NuGet** — Mapster 10.0.10, Swashbuckle 10.2.3, Redis 3.0.11, ASP.NET Core 10.0.9.
- **Tests** — Pi-hole test credentials marked as synthetic fixtures; gitleaks allowlist for unit tests.

### Frontend (`DataGateMonitorFrontend`)

- **Pi-hole UI** — status panel, admin DNS queries, top visited domains, profile-based DNS history.
- **OpenVPN** — user events page, app version summary, shared CN filter on stats.
- **Cert expiry** — settings UI, run detail with issues-only filter (Orval client).
- **GDPR** — cookie consent banner and privacy policy (admin + XRay portal).
- **API hygiene** — Orval-only clients; OpenAPI snapshot from dotnet export (v1.4.6).

### OpenVPN microservice (`DataGateOpenVpnManager`)

- **Pi-hole v6** — DNS query collector, runtime config API, admin diagnostics.
- **OpenVPN 2.7.4** — upgrade and new address parsing.
- **Easy-RSA** — fix `index.txt` path resolution; fewer false PKI warnings.
- **NuGet** — SharedModels 1.0.34, ASP.NET 10.0.9, Swashbuckle 10.2.3.

### Telegram bot (`OpenVPNGateBot`)

- SharedModels **1.0.25 → 1.0.27** (Pi-hole diagnostics contracts).
- NuGet bumps (Swashbuckle, EF Core, Npgsql, test SDK).

### XRay manager (`DataGateXRayManager`)

- JWT validation failure logging (caller context for Wazuh triage).
- SharedModels **1.0.25 → 1.0.27**.
- NuGet bumps.

---

## Test plan

- [ ] After merge: `git submodule update --init --recursive` on production checkout
- [ ] Deploy backend + frontend; smoke OpenVPN hub connections (no SignalR race errors)
- [ ] Smoke Pi-hole panels, DNS queries, health notifications
- [ ] Smoke cert expiry manual run
- [ ] Smoke GDPR cookie consent on admin and XRay portal
- [ ] Verify OpenVPN microservice Pi-hole collector on a staging VPN server